### PR TITLE
fix: dont validate amfID in GUTI

### DIFF
--- a/internal/tests/tests/utils/validate/registration_accept.go
+++ b/internal/tests/tests/utils/validate/registration_accept.go
@@ -82,9 +82,9 @@ func RegistrationAccept(opts *RegistrationAcceptOpts) error {
 
 	guti5GStr := buildGUTI5G(*opts.NASMsg.RegistrationAccept.GUTI5G)
 
-	prefix := fmt.Sprintf("%s%scafe", opts.Mcc, opts.Mnc)
+	prefix := opts.Mcc + opts.Mnc
 	if !strings.HasPrefix(guti5GStr, prefix) {
-		return fmt.Errorf("GUTI5G MCC/MNC/AMF ID not the expected value, got: %s, want prefix: %s", guti5GStr, prefix)
+		return fmt.Errorf("GUTI5G PLMN not the expected value, got: %s, want prefix: %s", guti5GStr, prefix)
 	}
 
 	snssaiBytes := opts.NASMsg.RegistrationAccept.AllowedNSSAI.GetSNSSAIValue()


### PR DESCRIPTION
# Description

As we add HA support, different nodes have different AMFID's and this validation is not correct anymore.
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
