### PR TITLE
fix: Remove IPv4 assumption in xn_handover_connectivity test

### DIFF
--- a/internal/gnb/handle_pdu_session_resource_setup_request.go
+++ b/internal/gnb/handle_pdu_session_resource_setup_request.go
@@ -209,7 +209,7 @@ func getPDUSessionInfoFromSetupRequestTransfer(gnb *GnodeB, transfer aper.OctetS
 		return nil, fmt.Errorf("gnb is nil, cannot determine N3 address family")
 	}
 
-	upfIp, err := parseUPFAddress(upfAddress, gnb.N3Address)
+	upfIp, err := ParseUPFAddress(upfAddress, gnb.N3Address)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse UPF address: %v", err)
 	}
@@ -226,7 +226,7 @@ func getPDUSessionInfoFromSetupRequestTransfer(gnb *GnodeB, transfer aper.OctetS
 	}, nil
 }
 
-// parseUPFAddress selects the UPF IP address from a 3GPP TransportLayerAddress BIT STRING
+// ParseUPFAddress selects the UPF IP address from a 3GPP TransportLayerAddress BIT STRING
 // that matches the IP family of the given gNB N3 address.
 //
 // The encoding per 3GPP TS 38.414 is:
@@ -235,7 +235,7 @@ func getPDUSessionInfoFromSetupRequestTransfer(gnb *GnodeB, transfer aper.OctetS
 //   - 20 bytes → dual-stack: first 4 bytes are IPv4, next 16 bytes are IPv6
 //
 // Returns an error when the UPF provides no address for the requested family.
-func parseUPFAddress(upfAddressBytes []byte, n3Addr netip.Addr) (string, error) {
+func ParseUPFAddress(upfAddressBytes []byte, n3Addr netip.Addr) (string, error) {
 	if len(upfAddressBytes) == 0 {
 		return "", fmt.Errorf("UPF transport layer address is empty")
 	}

--- a/internal/tests/tests/ue/xn_handover_connectivity.go
+++ b/internal/tests/tests/ue/xn_handover_connectivity.go
@@ -278,7 +278,7 @@ func (t XnHandoverConnectivity) Run(ctx context.Context, env engine.Env) error {
 	logger.Logger.Debug("Target gNB: received PathSwitchRequestAcknowledge")
 
 	// Parse the PathSwitchRequestAcknowledge to get the new UPF UL tunnel info
-	newULTeid, newUpfAddress, err := parsePathSwitchRequestAcknowledge(ackFrame, sourceGnbPDUSession.PDUSessionID)
+	newULTeid, newUpfAddress, err := parsePathSwitchRequestAcknowledge(ackFrame, sourceGnbPDUSession.PDUSessionID, targetN3Addr)
 	if err != nil {
 		return fmt.Errorf("could not parse PathSwitchRequestAcknowledge: %v", err)
 	}
@@ -337,7 +337,7 @@ func (t XnHandoverConnectivity) Run(ctx context.Context, env engine.Env) error {
 
 // parsePathSwitchRequestAcknowledge extracts the UPF UL tunnel information
 // (TEID + IP address) from the PathSwitchRequestAcknowledge for the given PDU session.
-func parsePathSwitchRequestAcknowledge(frame gnb.SCTPFrame, expectedPDUSessionID int64) (uint32, string, error) {
+func parsePathSwitchRequestAcknowledge(frame gnb.SCTPFrame, expectedPDUSessionID int64, n3Addr netip.Addr) (uint32, string, error) {
 	pdu, err := ngap.Decoder(frame.Data)
 	if err != nil {
 		return 0, "", fmt.Errorf("could not decode NGAP: %v", err)
@@ -385,7 +385,10 @@ func parsePathSwitchRequestAcknowledge(frame gnb.SCTPFrame, expectedPDUSessionID
 			teid := binary.BigEndian.Uint32(transfer.ULNGUUPTNLInformation.GTPTunnel.GTPTEID.Value)
 			ipBytes := transfer.ULNGUUPTNLInformation.GTPTunnel.TransportLayerAddress.Value.Bytes
 
-			upfAddress := fmt.Sprintf("%d.%d.%d.%d", ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3])
+			upfAddress, err := gnb.ParseUPFAddress(ipBytes, n3Addr)
+			if err != nil {
+				return 0, "", fmt.Errorf("could not parse UPF address: %v", err)
+			}
 
 			return teid, upfAddress, nil
 		}


### PR DESCRIPTION
# Description

The handover connectivity test was failing in the IPv6 case, because it was assuming IPv4. We now properly parse the addresses from the signalling and select the address family matching the new N3 address.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
