### PR TITLE
feat: Add support for IPv4v6 and IPv6 session types

### DIFF
--- a/cmd/core-tester/main.go
+++ b/cmd/core-tester/main.go
@@ -27,6 +27,7 @@ var (
 	gnbN2Address      string
 	gnbN3Address      string
 	ellaCoreN2Address string
+	pduSessionType    string
 	verbose           bool
 )
 
@@ -71,6 +72,7 @@ func main() {
 	registerCmd.Flags().StringVar(&gnbN2Address, "gnb-n2-address", "", "gNB N2 address")
 	registerCmd.Flags().StringVar(&gnbN3Address, "gnb-n3-address", "", "gNB N3 address")
 	registerCmd.Flags().StringVar(&ellaCoreN2Address, "ella-core-n2-address", "", "Ella Core N2 address")
+	registerCmd.Flags().StringVar(&pduSessionType, "pdu-session-type", "ipv4", "PDU session type: ipv4, ipv6, or ipv4v6")
 
 	for _, name := range []string{
 		"imsi",
@@ -86,6 +88,7 @@ func main() {
 		"gnb-n2-address",
 		"gnb-n3-address",
 		"ella-core-n2-address",
+		"pdu-session-type",
 	} {
 		if err := registerCmd.MarkFlagRequired(name); err != nil {
 			panic(fmt.Sprintf("failed to mark flag %q required: %v", name, err))
@@ -119,6 +122,7 @@ func Register(cmd *cobra.Command, args []string) {
 		GnbN2Address:      gnbN2Address,
 		GnbN3Address:      gnbN3Address,
 		EllaCoreN2Address: ellaCoreN2Address,
+		PDUSessionType:    pduSessionType,
 	}
 
 	err := register.Run(ctx, registerConfig)

--- a/internal/gnb/gtp.go
+++ b/internal/gnb/gtp.go
@@ -31,6 +31,7 @@ type Tunnel struct {
 
 type NewTunnelOpts struct {
 	UEIP             string
+	UEIPV6           string
 	UpfIP            string
 	TunInterfaceName string
 	ULteid           uint32
@@ -56,24 +57,43 @@ func (g *GnodeB) AddTunnel(opts *NewTunnelOpts) (*Tunnel, error) {
 		return nil, fmt.Errorf("cannot read TUN interface: %v", err)
 	}
 
-	ueAddr, err := netlink.ParseAddr(opts.UEIP)
+	err = netlink.LinkSetUp(eth)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse UE address: %v", err)
+		return nil, fmt.Errorf("could not set TUN interface UP: %v", err)
 	}
 
-	err = netlink.AddrAdd(eth, ueAddr)
+	err = delAutoLinkLocal(eth)
 	if err != nil {
-		return nil, fmt.Errorf("could not assign UE address to TUN interface: %v", err)
+		return nil, fmt.Errorf("could not clean up auto-assigned link-local addresses: %v", err)
+	}
+
+	if opts.UEIP != "" {
+		ueAddr, err := netlink.ParseAddr(opts.UEIP)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse UE IPv4 address: %v", err)
+		}
+
+		err = netlink.AddrAdd(eth, ueAddr)
+		if err != nil {
+			return nil, fmt.Errorf("could not assign UE IPv4 address to TUN interface: %v", err)
+		}
+	}
+
+	if opts.UEIPV6 != "" {
+		ueAddrV6, err := netlink.ParseAddr(opts.UEIPV6)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse UE IPv6 address: %v", err)
+		}
+
+		err = netlink.AddrAdd(eth, ueAddrV6)
+		if err != nil {
+			return nil, fmt.Errorf("could not assign UE IPv6 address to TUN interface: %v", err)
+		}
 	}
 
 	err = netlink.LinkSetMTU(eth, int(opts.MTU))
 	if err != nil {
 		return nil, fmt.Errorf("could not set MTU on TUN interface: %v", err)
-	}
-
-	err = netlink.LinkSetUp(eth)
-	if err != nil {
-		return nil, fmt.Errorf("could not set TUN interface UP: %v", err)
 	}
 
 	tunnel := &Tunnel{
@@ -264,4 +284,23 @@ func tunToGtp(conn *net.UDPConn, t *Tunnel) {
 			zap.Int("TEID", int(t.ulteid)),
 		)
 	}
+}
+
+func delAutoLinkLocal(eth netlink.Link) error {
+	addrs, err := netlink.AddrList(eth, netlink.FAMILY_V6)
+	if err != nil {
+		return fmt.Errorf("could not list IPv6 addresses: %v", err)
+	}
+
+	for _, addr := range addrs {
+		if addr.IP.IsLinkLocalUnicast() && !addr.IP.Equal(net.ParseIP("fe80::")) {
+			if err := netlink.AddrDel(eth, &addr); err != nil {
+				return fmt.Errorf("could not delete auto-assigned link-local address %s: %v", addr.IP.String(), err)
+			}
+
+			logger.GnbLogger.Debug("Deleted auto-assigned link-local address", zap.String("address", addr.IP.String()))
+		}
+	}
+
+	return nil
 }

--- a/internal/register/register.go
+++ b/internal/register/register.go
@@ -44,11 +44,16 @@ type Config struct {
 	GnbN2Address      string
 	GnbN3Address      string
 	EllaCoreN2Address string
+	PDUSessionType    string
 }
 
 // Run performs the full register-and-tunnel flow and blocks until ctx is
 // cancelled or an interrupt signal is received.
 func Run(ctx context.Context, cfg Config) error {
+	if err := validatePDUSessionType(cfg.PDUSessionType); err != nil {
+		return err
+	}
+
 	if len(cfg.IMSI) < 6 {
 		return fmt.Errorf("invalid IMSI %q: must be at least 6 digits", cfg.IMSI)
 	}
@@ -84,10 +89,12 @@ func Run(ctx context.Context, cfg Config) error {
 
 	logger.Logger.Info("received NGSetupResponse")
 
+	pduSessionType := convertPDUSessionType(cfg.PDUSessionType)
+
 	newUE, err := ue.NewUE(&ue.UEOpts{
 		GnodeB:         gNodeB,
 		PDUSessionID:   1,
-		PDUSessionType: nasMessage.PDUSessionTypeIPv4,
+		PDUSessionType: pduSessionType,
 		Msin:           cfg.IMSI[5:],
 		K:              cfg.Key,
 		OpC:            cfg.OPC,
@@ -152,10 +159,25 @@ func Run(ctx context.Context, cfg Config) error {
 	pduSession := gNodeB.GetPDUSession(ranUENGAPID, int64(pduSessionID))
 
 	uePduSession := newUE.GetPDUSession(pduSessionID)
-	ueIP := uePduSession.UEIP + "/16"
+
+	var (
+		ueIP   string
+		ueIPV6 string
+	)
+
+	switch uePduSession.PDUSessionVersion {
+	case nasMessage.PDUSessionTypeIPv4:
+		ueIP = uePduSession.UEIP + "/16"
+	case nasMessage.PDUSessionTypeIPv6:
+		ueIPV6 = uePduSession.UEIPV6 + "/64"
+	case nasMessage.PDUSessionTypeIPv4IPv6:
+		ueIP = uePduSession.UEIP + "/16"
+		ueIPV6 = uePduSession.UEIPV6 + "/64"
+	}
 
 	_, err = gNodeB.AddTunnel(&gnb.NewTunnelOpts{
 		UEIP:             ueIP,
+		UEIPV6:           ueIPV6,
 		UpfIP:            pduSession.UpfAddress,
 		TunInterfaceName: gtpInterfaceName,
 		ULteid:           pduSession.ULTeid,
@@ -180,6 +202,7 @@ func Run(ctx context.Context, cfg Config) error {
 		"Created GTP tunnel",
 		zap.String("interface", gtpInterfaceName),
 		zap.String("UE IP", ueIP),
+		zap.String("UE IP (IPv6)", ueIPV6),
 		zap.String("gNB IP", cfg.GnbN3Address),
 		zap.String("UPF IP", pduSession.UpfAddress),
 		zap.Uint32("LTEID", pduSession.ULTeid),
@@ -195,4 +218,24 @@ func Run(ctx context.Context, cfg Config) error {
 	logger.Logger.Info("shutting down")
 
 	return nil
+}
+
+func convertPDUSessionType(sessionType string) uint8 {
+	switch sessionType {
+	case "ipv6":
+		return nasMessage.PDUSessionTypeIPv6
+	case "ipv4v6":
+		return nasMessage.PDUSessionTypeIPv4IPv6
+	default:
+		return nasMessage.PDUSessionTypeIPv4
+	}
+}
+
+func validatePDUSessionType(sessionType string) error {
+	switch sessionType {
+	case "ipv4", "ipv6", "ipv4v6":
+		return nil
+	default:
+		return fmt.Errorf("invalid PDU session type %q: must be ipv4, ipv6, or ipv4v6", sessionType)
+	}
 }

--- a/internal/ue/build_pdu_session_establishment_request.go
+++ b/internal/ue/build_pdu_session_establishment_request.go
@@ -39,6 +39,11 @@ func BuildPduSessionEstablishmentRequest(opts *PduSessionEstablishmentRequestOpt
 	protocolConfigurationOptions := nasConvert.NewProtocolConfigurationOptions()
 	protocolConfigurationOptions.AddIPAddressAllocationViaNASSignallingUL()
 	protocolConfigurationOptions.AddDNSServerIPv4AddressRequest()
+
+	if opts.PDUSessionType == nasMessage.PDUSessionTypeIPv6 || opts.PDUSessionType == nasMessage.PDUSessionTypeIPv4IPv6 {
+		protocolConfigurationOptions.AddDNSServerIPv6AddressRequest()
+	}
+
 	pcoContents := protocolConfigurationOptions.Marshal()
 	pcoContentsLength := len(pcoContents)
 	pduSessionEstablishmentRequest.ExtendedProtocolConfigurationOptions.SetLen(uint16(pcoContentsLength))

--- a/internal/ue/handle_pdu_session_establishment_accept.go
+++ b/internal/ue/handle_pdu_session_establishment_accept.go
@@ -9,21 +9,147 @@ import (
 )
 
 func handlePDUSessionEstablishmentAccept(ue *UE, msg *nasMessage.PDUSessionEstablishmentAccept) error {
-	ueIP, err := ueIPFromNAS(msg.GetPDUAddressInformation())
-	if err != nil {
-		return fmt.Errorf("could not get UE IP from NAS PDU Address Information: %v", err)
+	addrInfo := msg.GetPDUAddressInformation()
+
+	pduSessionType := msg.SelectedSSCModeAndSelectedPDUSessionType.Octet & 0x07
+
+	logger.UeLogger.Debug(
+		"Received PDU Session Establishment Accept NAS message",
+		zap.String("IMSI", ue.UeSecurity.Supi),
+		zap.Uint8("PDU Session ID", msg.GetPDUSessionID()),
+		zap.Uint8("PTI", msg.GetPTI()),
+		zap.Uint8("Extended Protocol Discriminator", msg.GetExtendedProtocolDiscriminator()),
+		zap.Uint8("Message Identity", msg.GetMessageType()),
+		zap.Any("PDU Address Raw", addrInfo),
+		zap.Any("PDU Address Raw Hex", fmt.Sprintf("%#x", addrInfo)),
+		zap.Uint8("PDU Session Type (from SSC octet)", pduSessionType),
+	)
+
+	if msg.PDUAddress != nil {
+		logger.UeLogger.Debug(
+			"PDU Address IE details",
+			zap.Uint8("IEI", msg.PDUAddress.GetIei()),
+			zap.Uint8("Length", msg.PDUAddress.GetLen()),                                 //nolint:staticcheck // PDUAddress is a pointer field, not embedded
+			zap.Uint8("PDU Session Type Value", msg.PDUAddress.GetPDUSessionTypeValue()), //nolint:staticcheck // PDUAddress is a pointer field, not embedded
+			zap.Any("Octets", msg.PDUAddress.Octet[:msg.PDUAddress.GetLen()]),
+			zap.Any("Octets Hex", fmt.Sprintf("%#x", msg.PDUAddress.Octet[:msg.PDUAddress.GetLen()])),
+		)
 	}
 
-	mtu, err := mtuFromExtendProtocolConfigurationOptionsContents(
-		msg.GetExtendedProtocolConfigurationOptionsContents(),
-	)
+	if msg.SelectedSSCModeAndSelectedPDUSessionType.Octet != 0 {
+		logger.UeLogger.Debug(
+			"SSC Mode and PDU Session Type",
+			zap.Uint8("Octet", msg.SelectedSSCModeAndSelectedPDUSessionType.Octet),
+			zap.Uint8("SSC Mode", msg.SelectedSSCModeAndSelectedPDUSessionType.Octet>>3),
+			zap.Uint8("PDU Session Type", pduSessionType),
+		)
+	}
+
+	if msg.AuthorizedQosRules.Len != 0 {
+		logger.UeLogger.Debug(
+			"Authorized QoS Rules",
+			zap.Uint16("Length", msg.AuthorizedQosRules.GetLen()),
+			zap.Any("Buffer", msg.AuthorizedQosRules.Buffer[:msg.AuthorizedQosRules.GetLen()]),
+			zap.Any("Buffer Hex", fmt.Sprintf("%#x", msg.AuthorizedQosRules.Buffer[:msg.AuthorizedQosRules.GetLen()])),
+		)
+	}
+
+	if msg.SessionAMBR.GetLen() != 0 {
+		logger.UeLogger.Debug(
+			"Session AMBR",
+			zap.Uint8("Length", msg.SessionAMBR.GetLen()),
+			zap.Any("Octets", msg.SessionAMBR.Octet[:msg.SessionAMBR.GetLen()]),
+			zap.Any("Octets Hex", fmt.Sprintf("%#x", msg.SessionAMBR.Octet[:msg.SessionAMBR.GetLen()])),
+		)
+	}
+
+	if msg.Cause5GSM != nil {
+		logger.UeLogger.Debug(
+			"Cause 5GSM",
+			zap.Uint8("IEI", msg.Cause5GSM.GetIei()),
+			zap.Any("Octet", msg.Cause5GSM.Octet),
+		)
+	}
+
+	if msg.RQTimerValue != nil {
+		logger.UeLogger.Debug(
+			"RQ Timer Value",
+			zap.Uint8("IEI", msg.RQTimerValue.GetIei()),
+			zap.Any("Octet", msg.RQTimerValue.Octet),
+		)
+	}
+
+	if msg.SNSSAI != nil {
+		logger.UeLogger.Debug(
+			"SNSSAI",
+			zap.Uint8("IEI", msg.SNSSAI.GetIei()),
+			zap.Uint8("Length", msg.SNSSAI.GetLen()),
+			zap.Any("Octets", msg.SNSSAI.Octet[:msg.SNSSAI.GetLen()]),
+			zap.Any("Octets Hex", fmt.Sprintf("%#x", msg.SNSSAI.Octet[:msg.SNSSAI.GetLen()])),
+		)
+	}
+
+	if msg.AlwaysonPDUSessionIndication != nil {
+		logger.UeLogger.Debug(
+			"Always-on PDU Session Indication",
+			zap.Uint8("IEI", msg.AlwaysonPDUSessionIndication.GetIei()),
+			zap.Any("Octet", msg.AlwaysonPDUSessionIndication.Octet),
+		)
+	}
+
+	if msg.MappedEPSBearerContexts != nil {
+		logger.UeLogger.Debug(
+			"Mapped EPS Bearer Contexts",
+			zap.Uint8("IEI", msg.MappedEPSBearerContexts.GetIei()),
+			zap.Any("Mapped EPS Bearer Context", msg.MappedEPSBearerContexts.GetMappedEPSBearerContext()), //nolint:staticcheck // MappedEPSBearerContexts is a pointer field, not embedded
+		)
+	}
+
+	if msg.EAPMessage != nil {
+		logger.UeLogger.Debug(
+			"EAP Message",
+			zap.Uint8("IEI", msg.EAPMessage.GetIei()),
+			zap.Any("EAP Message", msg.EAPMessage.GetEAPMessage()), //nolint:staticcheck // EAPMessage is a pointer field, not embedded
+		)
+	}
+
+	if msg.DNN != nil {
+		logger.UeLogger.Debug(
+			"DNN",
+			zap.Uint8("IEI", msg.DNN.GetIei()),
+			zap.String("DNN", msg.DNN.GetDNN()), //nolint:staticcheck // DNN is a pointer field, not embedded
+		)
+	}
+
+	pcoContents := msg.GetExtendedProtocolConfigurationOptionsContents()
+	if len(pcoContents) > 0 {
+		logger.UeLogger.Debug(
+			"Extended Protocol Configuration Options",
+			zap.Any("PCO Contents", pcoContents),
+			zap.Any("PCO Contents Hex", fmt.Sprintf("%#x", pcoContents)),
+		)
+	}
+
+	qosFlowDescsRaw := msg.GetQoSFlowDescriptions()
+	if len(qosFlowDescsRaw) > 0 {
+		logger.UeLogger.Debug(
+			"QoS Flow Descriptions (raw)",
+			zap.Any("QoS Flow Descriptions", qosFlowDescsRaw),
+			zap.Any("QoS Flow Descriptions Hex", fmt.Sprintf("%#x", qosFlowDescsRaw)),
+		)
+	}
+
+	pduAddr, err := parsePduAddressInformation(addrInfo, pduSessionType)
+	if err != nil {
+		return fmt.Errorf("could not parse PDU address from NAS: %v", err)
+	}
+
+	mtu, err := mtuFromExtendProtocolConfigurationOptionsContents(pcoContents)
 	if err != nil {
 		return fmt.Errorf("could not get MTU from Extended Protocol Configuration Options: %v", err)
 	}
 
-	qosFlowDescs, err := parseAuthorizedQosFlowDescriptions(
-		msg.GetQoSFlowDescriptions(),
-	)
+	qosFlowDescs, err := parseAuthorizedQosFlowDescriptions(qosFlowDescsRaw)
 	if err != nil {
 		return fmt.Errorf("could not parse AuthorizedQosFlowDescriptions: %v", err)
 	}
@@ -34,20 +160,37 @@ func handlePDUSessionEstablishmentAccept(ue *UE, msg *nasMessage.PDUSessionEstab
 
 	qfi := qosFlowDescs[0].Qfi
 
+	var ipStr string
+
+	if pduAddr.IP.IsValid() {
+		ipStr = pduAddr.IP.String()
+	}
+
+	if pduAddr.IPV6.IsValid() {
+		if ipStr != "" {
+			ipStr += ", " + pduAddr.IPV6.String()
+		} else {
+			ipStr = pduAddr.IPV6.String()
+		}
+	}
+
 	logger.UeLogger.Debug(
-		"Received PDU Session Establishment Accept NAS message",
+		"Parsed PDU Session info",
 		zap.String("IMSI", ue.UeSecurity.Supi),
 		zap.Uint8("PDU Session ID", msg.GetPDUSessionID()),
-		zap.String("UE IP", ueIP.String()),
+		zap.String("UE IP", ipStr),
 		zap.Uint16("MTU", mtu),
 		zap.Uint8("QFI", qfi),
+		zap.Uint8("PDU Session Type", pduAddr.PDUSessionType),
 	)
 
 	ue.SetPDUSession(PDUSessionInfo{
-		PDUSessionID: msg.GetPDUSessionID(),
-		UEIP:         ueIP.String(),
-		MTU:          mtu,
-		QFI:          qfi,
+		PDUSessionID:      msg.GetPDUSessionID(),
+		UEIP:              pduAddr.IP.String(),
+		UEIPV6:            pduAddr.IPV6.String(),
+		MTU:               mtu,
+		QFI:               qfi,
+		PDUSessionVersion: pduAddr.PDUSessionType,
 	})
 
 	return nil

--- a/internal/ue/nas_utils.go
+++ b/internal/ue/nas_utils.go
@@ -10,6 +10,73 @@ import (
 	"github.com/free5gc/nas/nasMessage"
 )
 
+type PduAddressInfo struct {
+	IP             netip.Addr
+	IPV6           netip.Addr
+	PDUSessionType uint8
+}
+
+// parsePduAddressInformation decodes the PDU address per TS 24.501 section 9.11.4.10.
+//
+// Table 9.11.4.10.1 defines the PDU address information element structure:
+//
+//	Octet 3: PDU session type value (bits 1-3) + SI6LLA bit (bit 4) + spare bits
+//	Octet 4-11: IPv6 interface identifier (for IPv6 or IPv4v6)
+//	Octet 12-15: IPv4 address (for IPv4 or IPv4v6)
+//
+// The addrInfo slice (from GetPDUAddressInformation()) contains 12 bytes:
+// - For IPv4: octets 4-7 (IPv4 address) + 4 spare bytes
+// - For IPv6: octets 4-11 (IPv6 interface identifier)
+// - For IPv4v6: octets 4-11 (IPv6 interface identifier) + octets 12-15 (IPv4 address)
+func parsePduAddressInformation(addrInfo [12]uint8, pduSessionType uint8) (PduAddressInfo, error) {
+	info := PduAddressInfo{
+		PDUSessionType: pduSessionType,
+	}
+
+	switch pduSessionType {
+	case nasMessage.PDUSessionTypeIPv4:
+		ueIPString := fmt.Sprintf("%d.%d.%d.%d", addrInfo[0], addrInfo[1], addrInfo[2], addrInfo[3])
+
+		ueIP, err := netip.ParseAddr(ueIPString)
+		if err != nil {
+			return PduAddressInfo{}, fmt.Errorf("could not parse IPv4 address from NAS: %v", err)
+		}
+
+		info.IP = ueIP
+
+	case nasMessage.PDUSessionTypeIPv6:
+		var ifaceId [8]uint8
+		copy(ifaceId[:], addrInfo[0:8])
+		info.IPV6 = interfaceIdToLinkLocal(ifaceId)
+
+	case nasMessage.PDUSessionTypeIPv4IPv6:
+		var ifaceId [8]uint8
+		copy(ifaceId[:], addrInfo[0:8])
+		info.IPV6 = interfaceIdToLinkLocal(ifaceId)
+
+		ueIPString := fmt.Sprintf("%d.%d.%d.%d", addrInfo[8], addrInfo[9], addrInfo[10], addrInfo[11])
+
+		ueIP, err := netip.ParseAddr(ueIPString)
+		if err != nil {
+			return PduAddressInfo{}, fmt.Errorf("could not parse IPv4 address from NAS: %v", err)
+		}
+
+		info.IP = ueIP
+	}
+
+	return info, nil
+}
+
+func interfaceIdToLinkLocal(interfaceId [8]uint8) netip.Addr {
+	linkLocalPrefix := [8]uint8{0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+	var addr [16]byte
+	copy(addr[0:8], linkLocalPrefix[:])
+	copy(addr[8:16], interfaceId[:])
+
+	return netip.AddrFrom16(addr)
+}
+
 func getNasPduFromDLNASTransport(dlNas *nas.Message) (*nas.Message, error) {
 	payload := dlNas.DLNASTransport.GetPayloadContainerContents()
 	m := new(nas.Message)
@@ -20,17 +87,6 @@ func getNasPduFromDLNASTransport(dlNas *nas.Message) (*nas.Message, error) {
 	}
 
 	return m, nil
-}
-
-func ueIPFromNAS(ip [12]uint8) (netip.Addr, error) {
-	ueIPString := fmt.Sprintf("%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3])
-
-	ueIP, err := netip.ParseAddr(ueIPString)
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("could not parse UE IP: %s, %v", ueIPString, err)
-	}
-
-	return ueIP, nil
 }
 
 func mtuFromExtendProtocolConfigurationOptionsContents(pco_buf []byte) (uint16, error) {

--- a/internal/ue/ue.go
+++ b/internal/ue/ue.go
@@ -61,10 +61,12 @@ type Amf struct {
 }
 
 type PDUSessionInfo struct {
-	PDUSessionID uint8
-	UEIP         string
-	MTU          uint16
-	QFI          uint8
+	PDUSessionID      uint8
+	UEIP              string
+	UEIPV6            string
+	MTU               uint16
+	QFI               uint8
+	PDUSessionVersion uint8
 }
 
 type UE struct {


### PR DESCRIPTION
# Description

Adds support for IPv4v6 and IPv6 session types for the register command. The type of session can be chosen with the `--pdu-session-type` arguments, with either `ipv4`, `ipv6` or `ipv4v6`. If not provided, we default to `ipv4`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
